### PR TITLE
Add logging support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ This package was designed for flexibility.  The mmb_predict() function will take
 
 More Information
 ----------------
-Python 3 not fully supported.  One package dependency is not working in Python 3.5 and higher, but once that is updated the rest of this project is ready to support Python 3.
+Python 3 is fully supported.  We have tested up to Python 3.6.2
 
 
 License


### PR DESCRIPTION
Replace print statements with logging messages
I would also like to add in support to allow the modeldata.pickle to be moved into a dedicated repo that at run time it will request the data sample from github that matches it's version or have it convert a local copy to it's version before running. It saves massive time in my testing to ensure they are updated.

Also great news while python 2 does have this pickle issue it's still much slower than python 3 when it has the pickle issue. It's also interesting to note that they have different results based on the version of pickle and python.

Python 3.5.2 
Test without import issue
time python test.py 
malicious
benign
benign
benign
malicious

real    0m1.997s
user    0m0.672s
sys     0m1.520s



Python 2.7.12
Test with import issue
time python mmbot/test.py 
/sklearn/base.py:312: UserWarning: Trying to unpickle estimator DecisionTreeClassifier from version 0.18.2 when using version 0.19.0. 

malicious
benign
benign
benign
benign

real    0m25.111s
user    0m23.140s
sys     0m2.096s


Python 3.6.2 
Import error speed
(mmbotpython362)mmbot/ time python test.py
python3.6/site-packages/sklearn/base.py:312: UserWarning: Trying to unpickle estimator TfidfTransformer from version 0.18.2 when using version 0.19.0
  UserWarning)
malicious
benign
benign
benign
malicious

real    0m4.161s
user    0m1.764s
sys     0m2.656s


Python 3.6.2 
Without import issue speed
(mmbotpython362)/mmbot$ time python test.py 
malicious
benign
benign
benign
malicious

real    0m1.039s
user    0m0.592s
sys     0m0.712s