### PR TITLE
Remove old modeldata.pickle file

### DIFF
--- a/mmbot/model/modeldata.pickle
+++ b/mmbot/model/modeldata.pickle
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c0f80aff3907c75472691921eed74df2000c082c51ddb682132b8ca0096bbda4
-size 1058163909


### PR DESCRIPTION
Add new compressed modeldata.pickle.gz to be used if modeldata.pickle is not found as suggested by Allen Swackhamer to use .gz as it's supported in python 2 + 3. A faster method would be to use lzma if we only used python 3. 
Remove old modeldata.pickle file